### PR TITLE
Forward users to PlatformIO installation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,12 @@
 # Deviot
-Sublime Text plugin for IoT development using [platformio](http://platformio.org/) ecosystem and supporting more than **180+** boards!
+Sublime Text plugin for IoT development using [PlatformIO](http://platformio.org/) ecosystem and supporting **~200** boards!
 
-The integration with platformio is not 100% ready, but will be in the near future. 
+The integration with PlatformIO is not 100% ready, but will be in the near future. 
 If you want to help me, please feel free to do it at any way you can.
 
 ## Setup
-#### Windows
-* Install [python 2.x](https://www.python.org/downloads/) (In the *Customize* stage, choose `Add python.exe to Path`)
-* Install [pip](https://pip.pypa.io/en/stable/installing/) (Command console)
-* Update package installer using `pip install -U pip setuptools`
-* Install [platformio](http://platformio.org/#!/get-started) `pip install -U platformio` (Command console)
-* Add a new repository to Sublime Text `https://github.com/gepd/Deviot.git`
-* Install the package `Deviot` from the list
 
-#### OS X / Linux
-* Install pip from the terminal using `sudo easy_install pip` (OS X)
-* Update package installer using `pip install -U pip setuptools`
-* Install [platformio](http://platformio.org/#!/get-started) `pip install -U platformio`
+* [Install PlatformIO](http://platformio.org/#!/get-started)
 * Add a new repository to Sublime Text `https://github.com/gepd/Deviot.git`
 * Install the package `Deviot` from the list
 


### PR DESCRIPTION
I recommend to forward users to PlatformIO installation page, because this process simplifies from each new release. Later will be added native system packages for the popular OS.