### PR TITLE
Refactoring the Python detection.

### DIFF
--- a/beginning/pio_install.py
+++ b/beginning/pio_install.py
@@ -202,40 +202,28 @@ class PioInstall(object):
         if(not path.isdir(self.OUTPUT_PATH)):
             rename(extracted, self.OUTPUT_PATH)
 
-    def check_sym_link(self):
-        """Arch Linux
-
-        Check if python 2 is used with a symlink it's
-        commonly used in python2. When it's used it's
-        stored in a config file to be used by the plugin
-        """
-        cmd = ['python2', '--version']
-        out = run_command(cmd)
-
-        if(out[0] == 0):
-            dprint("symlink_detected")
-            self.version = sub(r'\D', '', out[1])
-            self.SYMLINK = 'python2'
-            save_setting('symlink', True)
 
     def check_python(self):
         """Python requirement
 
-        Check if python 2 is installed
+        Check if python 2 is installed and detect which symlink is used.
+        It's stored in a config file to be used by the plugin
         """
         self.version = None
 
         cmd = [self.SYMLINK, '--version']
         out = run_command(cmd)
 
-        if(out[0] > 0):
-            self.check_sym_link()
-
         if(out[0] == 0):
             self.version = sub(r'\D', '', out[1])
 
+        if(int(self.version[0]) is not 2):
+            self.SYMLINK = 'python2'
+
+            check_python()
+
         # show error and link to download
-        if(out[0] > 0 or int(self.version[0]) is 3):
+        if(out[0] > 0):
             from ..libraries.I18n import I18n
             _ = I18n().translate
             go_to = sublime.ok_cancel_dialog(
@@ -246,6 +234,8 @@ class PioInstall(object):
                     'open_url', {'url': 'https://www.python.org/downloads/'})
             
             exit(0)
+
+        save_setting('python_symlink', self.SYMLINK)
 
 
 def check_pio():

--- a/libraries/tools.py
+++ b/libraries/tools.py
@@ -88,7 +88,7 @@ def create_command(command):
     """
     external_bins = get_setting('external_bins', False)
     env_path = get_setting('env_path', False)
-    symlink = get_setting('symlink', False)
+    symlink = get_setting('python_symlink', 'python')
 
     if(not env_path):
         return command
@@ -96,19 +96,17 @@ def create_command(command):
     _os = platform()
 
     if(_os is 'osx'):
-        exe = 'python' if(not symlink) else 'python2'
         options = ['-m', command[0]]
     else:
-        exe = command[0]
         options = []
 
-    executable = exe
+    executable = symlink
 
     if(not external_bins):
         from . import paths
         
         bin_dir = paths.getEnvBinDir()
-        executable = path.join(bin_dir, exe)
+        executable = path.join(bin_dir, symlink)
 
     cmd = ['"%s"' % (executable)]
     cmd.extend(options)


### PR DESCRIPTION
On Gentoo (and the Arch Linux machine I had access to), the following condition is never met.
```
        if(out[0] > 0):
            self.check_sym_link()
```

This refactor will check the version, and if it does not match 2.x it will try a python2 symlink, if this still does not work, errors out with the download dialog.
Also stores the symlink name in the configuration.

Would someone be able to test the OSX implementation and the `if(not external_bins):` statement?

For me this fixed my issue reported at #117 